### PR TITLE
Increase max-time and retry on error

### DIFF
--- a/internal-functions
+++ b/internal-functions
@@ -128,6 +128,14 @@ fn-query-status(){
     AUTH_URL="$AUTH_URL/Auth"
   fi
 
-  local USER_INFO_URL="https://$AUTH_URL/v2/users/$USER/"
-  curl -sS --insecure --max-time 10 --retry 5 --header "$HEADER" "$USER_INFO_URL" | jq ".$FIELD" | grep -q 'true'
+  local USER_INFO_URL="https://$AUTH_URL/v2/users/$USER/"  
+  RESPONSE=$(curl -sS --insecure --max-time 10 --retry 5 --header "$HEADER" --write-out "\n%{http_code}" "$USER_INFO_URL")
+  RESPONSE_BODY=$(echo "$RESPONSE" | awk "NR==1")
+  STATUS_CODE=$(echo "$RESPONSE" | awk "NR==2")
+
+  if [[ "$STATUS_CODE" != "200" ]]; then
+    dokku_log_fail "Authentication check timed out. Your system might be overloaded. Please try again after some time."
+  fi
+
+  echo "$RESPONSE_BODY" | jq ".$FIELD" | grep -q 'true'
 }

--- a/internal-functions
+++ b/internal-functions
@@ -129,5 +129,5 @@ fn-query-status(){
   fi
 
   local USER_INFO_URL="https://$AUTH_URL/v2/users/$USER/"
-  curl -sk --max-time 3 --header "$HEADER" "$USER_INFO_URL" | jq ".$FIELD" | grep -q 'true'
+  curl -sS --insecure --max-time 10 --retry 5 --header "$HEADER" "$USER_INFO_URL" | jq ".$FIELD" | grep -q 'true'
 }

--- a/internal-functions
+++ b/internal-functions
@@ -133,8 +133,13 @@ fn-query-status(){
   RESPONSE_BODY="$(echo "$RESPONSE" | awk "NR==1")"
   STATUS_CODE="$(echo "$RESPONSE" | awk "NR==2")"
 
-  if [[ "$STATUS_CODE" != "200" ]]; then
+  if [[ "$STATUS_CODE" == "503" ]]; then
     dokku_log_fail "Authentication check timed out. Your system might be overloaded. Please try again after some time."
+  fi
+
+  if [[ "$STATUS_CODE" != "200" ]]; then
+    dokku_log_fail "A $STATUS_CODE level error occurred during an authentication check. " \ 
+                   "Try again in a little bit or reach out to onpremise.support@plot.ly"
   fi
 
   echo "$RESPONSE_BODY" | jq ".$FIELD" | grep -q 'true'

--- a/internal-functions
+++ b/internal-functions
@@ -134,7 +134,7 @@ fn-query-status(){
   STATUS_CODE="$(echo "$RESPONSE" | awk "NR==2")"
 
   if [[ "$STATUS_CODE" == "503" ]]; then
-    dokku_log_fail "Authentication check timed out. Your system might be overloaded. Please try again after some time."
+    dokku_log_fail "Authentication check timed out. Your system might be overloaded. Please try again in a little bit."
   fi
 
   if [[ "$STATUS_CODE" != "200" ]]; then

--- a/internal-functions
+++ b/internal-functions
@@ -129,9 +129,9 @@ fn-query-status(){
   fi
 
   local USER_INFO_URL="https://$AUTH_URL/v2/users/$USER/"  
-  RESPONSE=$(curl -sS --insecure --max-time 10 --retry 5 --header "$HEADER" --write-out "\n%{http_code}" "$USER_INFO_URL")
-  RESPONSE_BODY=$(echo "$RESPONSE" | awk "NR==1")
-  STATUS_CODE=$(echo "$RESPONSE" | awk "NR==2")
+  RESPONSE="$(curl -sS --insecure --max-time 10 --retry 5 --header "$HEADER" --write-out "\n%{http_code}" "$USER_INFO_URL")"
+  RESPONSE_BODY="$(echo "$RESPONSE" | awk "NR==1")"
+  STATUS_CODE="$(echo "$RESPONSE" | awk "NR==2")"
 
   if [[ "$STATUS_CODE" != "200" ]]; then
     dokku_log_fail "Authentication check timed out. Your system might be overloaded. Please try again after some time."

--- a/internal-functions
+++ b/internal-functions
@@ -138,7 +138,7 @@ fn-query-status(){
   fi
 
   if [[ "$STATUS_CODE" != "200" ]]; then
-    dokku_log_fail "A $STATUS_CODE level error occurred during an authentication check. " \ 
+    dokku_log_fail "A $STATUS_CODE level error occurred during an authentication check. " \
                    "Try again in a little bit or reach out to onpremise.support@plot.ly"
   fi
 


### PR DESCRIPTION
Fixes https://github.com/plotly/streambed/issues/14120
  - [x] Test on on-prem

Test Plan:

Test 1:
  - Create an app. Set `is_dash_creator` status to `False` in the database for the app-owner.
  - Redeploy the app. Should get the "not a chart creator.." error message.

Test 2:
  - Deploy an app.
  - ssh into the server and stop the streambed container: `docker stop streambed`
  - Try redeploying the app. It should fail with "Authentication check timed out.." error.