### PR TITLE
Test improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ hosting. (See below for notes and limitations.)
 dokku plugin:install https://github.com/dokku-community/dokku-acl.git acl
 ```
 
+## running tests locally
+
+clone and build `dokku`:
+```shell
+git clone https://github.com/dokku/dokku.git
+cd dokku; make go-build
+```
+
+Run tests:
+```shell
+DOKKU_ROOT="../path-to-dokku-dir" DOKKU_SYSTEM_USER=$USER make test
+```
+
 ## commands
 
 ```shell

--- a/tests/hook_user_auth.bats
+++ b/tests/hook_user_auth.bats
@@ -20,13 +20,21 @@ setup() {
   TMP=$(mktemp -d)
   export DOKKU_LIB_ROOT="$TMP"
   export PLOTLY_STREAMBED_HOST="localhost:4443/false"
-  python3 "$BATS_TEST_DIRNAME/bin/test_server.py" &
+
+  # Set up test server at the start of tests:
+  if [ "$BATS_TEST_NUMBER" -eq 1 ]; then
+    setupTestServer
+  fi
 }
 
 teardown() {
   sudo -u $DOKKU_SYSTEM_USER rm -rf "${APP_DIR:?}"
   rm -rf "$TMP"
-  kill $(pgrep -f 'test_server')
+
+  # Tear Down test server at the end of all tests:
+  if [ "$BATS_TEST_NUMBER" -eq ${#BATS_TEST_NAMES[@]} ]; then
+    tearDownTestServer
+  fi
 }
 
 @test "($PLUGIN_COMMAND_PREFIX:hook-user-auth) allows all commands by default" {

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -13,7 +13,7 @@ echo "Dokku version $DOKKU_VERSION"
 git checkout $DOKKU_VERSION > /dev/null
 rm -rf $DOKKU_ROOT/plugins/acl
 
-if grep go-build Makefile > /dev/null; then
+if [[ "$BUILD_DOKKU" == "1" ]]; then
   mv "$BIN_STUBS/docker" "$BIN_STUBS/docker-stub" || true
   make go-build
   mv "$BIN_STUBS/docker-stub" "$BIN_STUBS/docker"

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -11,8 +11,10 @@ fi
 cd $DOKKU_ROOT
 echo "Dokku version $DOKKU_VERSION"
 git checkout $DOKKU_VERSION > /dev/null
+rm -rf $DOKKU_ROOT/plugins/acl
+
 if grep go-build Makefile > /dev/null; then
-  mv "$BIN_STUBS/docker" "$BIN_STUBS/docker-stub"
+  mv "$BIN_STUBS/docker" "$BIN_STUBS/docker-stub" || true
   make go-build
   mv "$BIN_STUBS/docker-stub" "$BIN_STUBS/docker"
 fi
@@ -24,7 +26,6 @@ test -f /etc/init.d/nginx || {
 }
 
 source "$(dirname "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)")/config"
-rm -rf $DOKKU_ROOT/plugins/$PLUGIN_COMMAND_PREFIX
 mkdir -p $DOKKU_ROOT/plugins/$PLUGIN_COMMAND_PREFIX $DOKKU_ROOT/plugins/$PLUGIN_COMMAND_PREFIX/subcommands
 find ./ -maxdepth 1 -type f -exec cp '{}' $DOKKU_ROOT/plugins/$PLUGIN_COMMAND_PREFIX \;
 find ./subcommands -maxdepth 1 -type f -exec cp '{}' $DOKKU_ROOT/plugins/$PLUGIN_COMMAND_PREFIX/subcommands \;

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 export DOKKU_QUIET_OUTPUT=1
-export DOKKU_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/dokku"
+export DOKKU_ROOT="${DOKKU_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/dokku}"
 export DOKKU_VERSION=${DOKKU_VERSION:-"master"}
 export PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/bin:$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/dokku:$PATH"
 export PLUGIN_COMMAND_PREFIX="acl"

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 export DOKKU_QUIET_OUTPUT=1
+
+if [[ -z "$DOKKU_ROOT" ]]; then
+  export BUILD_DOKKU=1
+fi
 export DOKKU_ROOT="${DOKKU_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/dokku}"
 export DOKKU_VERSION=${DOKKU_VERSION:-"master"}
 export PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/bin:$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/dokku:$PATH"

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -72,3 +72,18 @@ assert_output() {
   fi
   assert_equal "$expected" "$output"
 }
+
+setupTestServer() {
+  nohup python3 "$BATS_TEST_DIRNAME/bin/test_server.py" &
+  echo $! > /tmp/python.pid
+  echo "Process ID $(cat /tmp/python.pid)"
+  while [ "$STATUS_CODE" != "200" ]; do
+    STATUS_CODE=$(curl -s -o /dev/null -I -w "%{http_code}" http://www.example.org/)
+    echo "Waiting for test server to come up.."
+  done
+}
+
+tearDownTestServer() {
+  kill -quit "$(cat /tmp/python.pid)"
+  ps -p "$(cat /tmp/python.pid)"  >/dev/null && kill -9 "$(cat /tmp/python.pid)"
+}


### PR DESCRIPTION
Test improvements:
  - Wait for server to start up before running tests. (Fixes intermittent failures)
  - Setup and teardown HTTP server only at the beginning and end of tests.
  - Allow setting `DOKKU_ROOT` through environment.
  - Do not build dokku from source when `DOKKU_ROOT` is specified.
  - Update readme for instructions on how to run tests.
