### PR TITLE
Test DOKKU with same version as DDS.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ dist: trusty
 language: bash
 env:
   - DOKKU_VERSION=master DOKKU_SYSTEM_GROUP=travis DOKKU_SYSTEM_USER=travis
-  - DOKKU_VERSION=v0.19.11 DOKKU_SYSTEM_GROUP=travis DOKKU_SYSTEM_USER=travis
+  - DOKKU_VERSION=v0.20.1 DOKKU_SYSTEM_GROUP=travis DOKKU_SYSTEM_USER=travis
 script: make test


### PR DESCRIPTION
Part of https://github.com/plotly/streambed/issues/14217

This PR updates travis config to test dokku-acl with the same version as being used in DDS (DDS PR: https://github.com/plotly/dash-deployment-server/pull/712)